### PR TITLE
Set fixed versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
 	"description": "Install Bower packages.",
 	"main": "index.js",
 	"dependencies": {
-		"bower": "latest",
-		"gulp-util": "latest",
-		"through2": "latest",
-		"walk": "latest"
+		"bower": "^1.3.12",
+		"gulp-util": "3.0.1",
+		"through2": "0.6.2",
+		"walk": "2.3.3"
 	},
 	"devDependencies": {
 		"gulp": "latest",


### PR DESCRIPTION
Because "walk" just had a breaking change in the way that walk parses directories. I.e. you now need to add `directory: 'bower_components'` in the gulp-bower config because walk breaks on the default `directory: './bower_components'`.
